### PR TITLE
Improve pause/resume experience

### DIFF
--- a/src/common/GenerateCar.ts
+++ b/src/common/GenerateCar.ts
@@ -26,7 +26,7 @@ export default class GenerateCar {
         }
       }
       // Somehow, win32 has generate-car binary at same PATH as singularity executable
-      if (!GenerateCar.path && process.platform !== 'win32') {
+      if (!GenerateCar.path) {
         throw new Error('Cannot find generate-car, please report this as a bug');
       }
     }

--- a/src/deal-preparation/DealPreparationService.ts
+++ b/src/deal-preparation/DealPreparationService.ts
@@ -336,8 +336,12 @@ export default class DealPreparationService extends BaseService {
       }
     }
 
-    await found.remove();
-    await Datastore.GenerationRequestModel.deleteMany({ datasetId: found.id });
+    await found.delete();
+    for (const generationRequest of await Datastore.GenerationRequestModel.find({ datasetId: found.id })) {
+      await Datastore.InputFileListModel.deleteMany({ generationId: generationRequest.id });
+      await Datastore.OutputFileListModel.deleteMany({ generationId: generationRequest.id });
+      await generationRequest.delete();
+    }
 
     response.end();
   }

--- a/src/deal-preparation/DealPreparationService.ts
+++ b/src/deal-preparation/DealPreparationService.ts
@@ -360,7 +360,7 @@ export default class DealPreparationService extends BaseService {
     const actionMap = {
       resume: [{ status: 'paused' }, { status: 'active', workerId: null }],
       pause: [{ status: 'active', workerId: null }, { status: 'paused' }],
-      retry: [{ status: 'error' }, { status: 'active', errorMessage: undefined, workerId: null }]
+      retry: [{ status: 'error' }, { status: 'active', errorMessage: null, workerId: null }]
     };
 
     const changed = (await Datastore.ScanningRequestModel.findOneAndUpdate({

--- a/src/deal-preparation/DealPreparationWorker.ts
+++ b/src/deal-preparation/DealPreparationWorker.ts
@@ -140,7 +140,7 @@ export default class DealPreparationWorker extends BaseService {
 
   public static async invokeGenerateCar (input: string, outDir: string, p: string, tmpDir?: string)
     : Promise<[stdout: string, stderr: string, statusCode: number | null]> {
-    const cmd = GenerateCar.path ?? 'generate-car';
+    const cmd = GenerateCar.path!;
     const args = ['-o', outDir, '-p', p];
     if (tmpDir) {
       args.push('-t', tmpDir);

--- a/src/deal-preparation/DealPreparationWorker.ts
+++ b/src/deal-preparation/DealPreparationWorker.ts
@@ -53,16 +53,35 @@ export default class DealPreparationWorker extends BaseService {
   }
 
   private async scan (request: ScanningRequest): Promise<void> {
-    this.logger.debug(`Started scanning.`, { id: request.id, name: request.name, path: request.path, minSize: request.minSize, maxSize: request.maxSize });
+    this.logger.info(`Started scanning.`, { id: request.id, name: request.name, path: request.path, minSize: request.minSize, maxSize: request.maxSize });
     let index = 0;
+    const deleted = (await Datastore.GenerationRequestModel.deleteMany({ datasetId: request.id, status: 'created' })).deletedCount;
+    if (deleted > 0) {
+      this.logger.info(`Deleted ${deleted} pending generation requests`);
+    }
+    const lastGeneration = await Datastore.GenerationRequestModel.findOne({ datasetId: request.id, status: { $ne: 'created' } }, { _id: 1, index: 1 }, { sort: { index: -1 } });
+    let lastFile: string | undefined;
+    if (lastGeneration) {
+      const lastFileList = await Datastore.InputFileListModel.findOne({ generationId: lastGeneration._id, index: lastGeneration.index });
+      if (!lastFileList) {
+        this.logger.error('Found last generation but not the file list. Please report this as a bug.', { id: lastGeneration._id, index: lastGeneration.index });
+        throw new Error('Found last generation but not the file list. Please report this as a bug.');
+      }
+      lastFile = lastFileList.fileList[lastFileList.fileList.length - 1].path;
+      this.logger.info(`Resuming scanning. Skip creating generation request until ${lastFile} is reached.`);
+    }
     for await (const fileList of Scanner.scan(request.path, request.minSize, request.maxSize)) {
-      const existing = await Datastore.GenerationRequestModel.findOne({ datasetId: request.id, index }, { _id: 1, status: 1 });
-      if (existing) {
-        if (existing.status === 'created') {
-          await Datastore.GenerationRequestModel.findByIdAndDelete(existing.id, { projection: { _id: 1 } });
-        } else {
-          continue;
+      if (!await Datastore.ScanningRequestModel.findById(request.id)) {
+        this.logger.info('The scanning request has been removed. Scanning stopped.', { id: request.id, name: request.name });
+        return;
+      }
+      if (lastFile) {
+        if (fileList.some(fileInfo => fileInfo.path === lastFile)) {
+          this.logger.info(`Reached the last file ${lastFile}, resume creating generation request.`);
+          lastFile = undefined;
         }
+        index++;
+        continue;
       }
       const generationRequest = await Datastore.GenerationRequestModel.create({
         datasetId: request.id,
@@ -73,6 +92,7 @@ export default class DealPreparationWorker extends BaseService {
         index,
         status: 'created'
       });
+      this.logger.info('Created a new generation request.', { id: request.id, name: request.name, index });
       for (let i = 0; i < fileList.length; i += 1000) {
         await Datastore.InputFileListModel.updateOne({
           generationId: generationRequest.id,
@@ -87,18 +107,20 @@ export default class DealPreparationWorker extends BaseService {
           upsert: true,
           projection: { _id: 1 }
         });
+        this.logger.debug('Created new INPUT file list for the generation request.', { id: request.id, name: request.name, index, from: i, to: i + 1000 });
       }
       await Datastore.GenerationRequestModel.findByIdAndUpdate(generationRequest.id, {
         status: 'active'
       }, { projection: { _id: 1 } });
+      this.logger.info('Marking generation request to active', { id: request.id, name: request.name, index });
       index++;
       if ((await Datastore.ScanningRequestModel.findById(request.id))?.status === 'paused') {
         this.logger.info(`Scanning request has been paused.`);
         return;
       }
     }
-    this.logger.debug(`Finished scanning. Inserted ${index} tasks.`);
     await Datastore.ScanningRequestModel.findByIdAndUpdate(request.id, { status: 'completed', workerId: null });
+    this.logger.info(`Finished scanning. Marking scanning to completed. Inserted ${index} generation tasks.`);
   }
 
   private async generate (request: GenerationRequest, input: string): Promise<[stdout: string, stderr: string, statusCode: number | null]> {
@@ -221,6 +243,7 @@ export default class DealPreparationWorker extends BaseService {
           upsert: true,
           projection: { _id: 1 }
         });
+        this.logger.debug('Created new OUTPUT file list for the generation request.', { id: newGenerationWork.id, name: newGenerationWork.datasetName, index: newGenerationWork.index, from: i, to: i + 1000 });
       }
       await Datastore.GenerationRequestModel.findByIdAndUpdate(newGenerationWork.id, {
         status: 'completed',
@@ -228,6 +251,7 @@ export default class DealPreparationWorker extends BaseService {
         pieceSize: output.PieceSize,
         pieceCid: output.PieceCid,
         carSize: carFileStat.size,
+        errorMessage: null,
         workerId: null
       }, {
         projection: { _id: 1 }

--- a/src/deal-preparation/DealPreparationWorker.ts
+++ b/src/deal-preparation/DealPreparationWorker.ts
@@ -62,9 +62,9 @@ export default class DealPreparationWorker extends BaseService {
     const lastGeneration = await Datastore.GenerationRequestModel.findOne({ datasetId: request.id, status: { $ne: 'created' } }, { _id: 1, index: 1 }, { sort: { index: -1 } });
     let lastFile: string | undefined;
     if (lastGeneration) {
-      const lastFileList = await Datastore.InputFileListModel.findOne({ generationId: lastGeneration._id, index: lastGeneration.index });
+      const lastFileList = await Datastore.InputFileListModel.findOne({ generationId: lastGeneration.id, index: lastGeneration.index });
       if (!lastFileList) {
-        this.logger.error('Found last generation but not the file list. Please report this as a bug.', { id: lastGeneration._id, index: lastGeneration.index });
+        this.logger.error('Found last generation but not the file list. Please report this as a bug.', { id: lastGeneration.id, index: lastGeneration.index });
         throw new Error('Found last generation but not the file list. Please report this as a bug.');
       }
       lastFile = lastFileList.fileList[lastFileList.fileList.length - 1].path;


### PR DESCRIPTION
1. More logging from preparation worker
2. Resuming a scanning request will now start from last scanned file
3. Remove a dataset should also remove input/output file list, and stop all CAR generation
4. Pause an ongoing scan and generation request