### PR TITLE
Port CSV Generation into master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "mongodb-memory-server": "^8.4.1",
         "mongoose": "^6.2.7",
         "node-cron": "^3.0.1",
+        "objects-to-csv": "^1.3.6",
         "picomatch": "^2.3.1",
         "toml": "^3.0.0",
         "winston": "^3.6.0",
@@ -1879,6 +1880,14 @@
       "version": "3.2.3",
       "license": "MIT"
     },
+    "node_modules/async-csv": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/async-csv/-/async-csv-2.1.3.tgz",
+      "integrity": "sha512-mpsCN+D7mzZeqrlDw7UTPhvDQDlx1i819E9fbKIt8drkgED5FSOlBv3Rk/+sXdevnO2wwlRkVOQ4kdT0AyqPqQ==",
+      "dependencies": {
+        "csv": "^5.1.3"
+      }
+    },
     "node_modules/async-mutex": {
       "version": "0.3.2",
       "license": "MIT",
@@ -2558,6 +2567,35 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.3.tgz",
+      "integrity": "sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==",
+      "dependencies": {
+        "csv-generate": "^3.4.3",
+        "csv-parse": "^4.16.3",
+        "csv-stringify": "^5.6.5",
+        "stream-transform": "^2.1.3"
+      },
+      "engines": {
+        "node": ">= 0.1.90"
+      }
+    },
+    "node_modules/csv-generate": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.3.tgz",
+      "integrity": "sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw=="
+    },
+    "node_modules/csv-parse": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
+      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+    },
+    "node_modules/csv-stringify": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
+      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
     "node_modules/dag-jose": {
       "version": "1.0.0",
@@ -7216,6 +7254,14 @@
       "version": "1.2.6",
       "license": "MIT"
     },
+    "node_modules/mixme": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.4.tgz",
+      "integrity": "sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==",
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "license": "MIT",
@@ -7891,6 +7937,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/objects-to-csv": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/objects-to-csv/-/objects-to-csv-1.3.6.tgz",
+      "integrity": "sha512-383eSpS3hmgCksW85KIqBtcbgSW5DDVsCmzLoM6C3q4yzOX2rmtWxF4pbLJ76fz+ufA+4/SwAT4QdaY6IUWmAg==",
+      "dependencies": {
+        "async-csv": "^2.1.3"
       }
     },
     "node_modules/observable-webworkers": {
@@ -9262,6 +9316,14 @@
       "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "dependencies": {
         "get-iterator": "^1.0.2"
+      }
+    },
+    "node_modules/stream-transform": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
+      "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
+      "dependencies": {
+        "mixme": "^0.5.1"
       }
     },
     "node_modules/streaming-iterables": {
@@ -11575,6 +11637,14 @@
     "async": {
       "version": "3.2.3"
     },
+    "async-csv": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/async-csv/-/async-csv-2.1.3.tgz",
+      "integrity": "sha512-mpsCN+D7mzZeqrlDw7UTPhvDQDlx1i819E9fbKIt8drkgED5FSOlBv3Rk/+sXdevnO2wwlRkVOQ4kdT0AyqPqQ==",
+      "requires": {
+        "csv": "^5.1.3"
+      }
+    },
     "async-mutex": {
       "version": "0.3.2",
       "requires": {
@@ -12071,6 +12141,32 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "csv": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.3.tgz",
+      "integrity": "sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==",
+      "requires": {
+        "csv-generate": "^3.4.3",
+        "csv-parse": "^4.16.3",
+        "csv-stringify": "^5.6.5",
+        "stream-transform": "^2.1.3"
+      }
+    },
+    "csv-generate": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.3.tgz",
+      "integrity": "sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw=="
+    },
+    "csv-parse": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
+      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+    },
+    "csv-stringify": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
+      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
     "dag-jose": {
       "version": "1.0.0",
@@ -15525,6 +15621,11 @@
     "minimist": {
       "version": "1.2.6"
     },
+    "mixme": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.4.tgz",
+      "integrity": "sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw=="
+    },
     "mkdirp": {
       "version": "1.0.4"
     },
@@ -16007,6 +16108,14 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
+      }
+    },
+    "objects-to-csv": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/objects-to-csv/-/objects-to-csv-1.3.6.tgz",
+      "integrity": "sha512-383eSpS3hmgCksW85KIqBtcbgSW5DDVsCmzLoM6C3q4yzOX2rmtWxF4pbLJ76fz+ufA+4/SwAT4QdaY6IUWmAg==",
+      "requires": {
+        "async-csv": "^2.1.3"
       }
     },
     "observable-webworkers": {
@@ -16955,6 +17064,14 @@
       "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "requires": {
         "get-iterator": "^1.0.2"
+      }
+    },
+    "stream-transform": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
+      "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
+      "requires": {
+        "mixme": "^0.5.1"
       }
     },
     "streaming-iterables": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "mongodb-memory-server": "^8.4.1",
     "mongoose": "^6.2.7",
     "node-cron": "^3.0.1",
+    "objects-to-csv": "^1.3.6",
     "picomatch": "^2.3.1",
     "toml": "^3.0.0",
     "winston": "^3.6.0",

--- a/src/replication/DealReplicationService.ts
+++ b/src/replication/DealReplicationService.ts
@@ -277,7 +277,7 @@ export default class DealReplicationService extends BaseService {
           const csv = new ObjectsToCsv(csvRow);
           const configDir = config.util.getEnv('NODE_CONFIG_DIR');
           await fs.mkdirp(path.join(configDir, 'csv'));
-          if (await fs.pathExists('${configDir}/csv')) {
+          if (await fs.pathExists(path.join(configDir, 'csv'))) {
             const filename = `${configDir}/csv/${deals[0].provider}_${id}.csv`;
             await csv.toDisk(filename);
             response.end(`CSV saved to ${filename}`);

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -521,6 +521,20 @@ replication.command('resume').description('Resume a paused deal replication requ
     }
     CliUtil.renderResponse(response.data, options.json);
   });
+
+  replication.command('csv').description('Write a deal replication result as csv.')
+  .argument('<id>', 'Existing ID of deal replication request.')
+  .action(async (id) => {
+    let response!: AxiosResponse;
+    try {
+      const url: string = config.get('connection.deal_replication_service');
+      response = await axios.get(`${url}/replication/${id}/csv`);
+    } catch (error) {
+      CliUtil.renderErrorAndExit(error);
+    }
+    CliUtil.renderResponse(response.data, false);
+  });
+  
 program.showSuggestionAfterError();
 program.showHelpAfterError('(add --help for additional information)');
 program.parse();


### PR DESCRIPTION
@kernelogic has a nice branch that generates a CSV for a replication request that is useful for offline deal importing. 
The current branch looks to have to many changes than necessary, so I have striped down the core function of this branch, changed where the csv is stored and some logic around creating the storage dir.

All Credit to @kernelogic for this one, I just tidied it up for master