### PR TITLE
Feat: Dont Import deals past StartEpoch

### DIFF
--- a/src/import/ImportUtil.ts
+++ b/src/import/ImportUtil.ts
@@ -179,7 +179,7 @@ export default class ImportUtil {
       //Skip over already expired deals
       let currentHeight = HeightFromCurrentTime();
       if (deal.StartEpoch < currentHeight) {
-        console.log(`Proposal has expired, skipping: ${proposalCid['/']}`);
+        console.log(`Proposal has expired, skipping: ${deal.proposalCid['/']}`);
         ImportUtil.knownBadProposalCids.push(deal.proposalCid['/']);
         continue;
       }

--- a/src/import/ImportUtil.ts
+++ b/src/import/ImportUtil.ts
@@ -8,6 +8,7 @@ import { sleep } from '../common/Util';
 import MultipartDownloader from 'multipart-download';
 import { ErrorMessage } from './ErrorMessage';
 import { AbortSignal } from '../common/AbortSignal';
+import { HeightFromCurrentTime } from '../common/ChainHeight';
 
 export default class ImportUtil {
   public static throwError (message: string) {
@@ -173,6 +174,13 @@ export default class ImportUtil {
         continue;
       }
       if (ImportUtil.knownBadProposalCids.includes(deal.ProposalCid['/'])) {
+        continue;
+      }
+      //Skip over already expired deals
+      let currentHeight = HeightFromCurrentTime();
+      if (deal.StartEpoch < currentHeight) {
+        console.log(`Proposal has expired, skipping: ${proposalCid['/']}`);
+        ImportUtil.knownBadProposalCids.push(deal.proposalCid['/']);
         continue;
       }
       let existingPath: string | undefined;

--- a/src/import/ImportUtil.ts
+++ b/src/import/ImportUtil.ts
@@ -178,9 +178,9 @@ export default class ImportUtil {
       }
       //Skip over already expired deals
       let currentHeight = HeightFromCurrentTime();
-      if (deal.StartEpoch < currentHeight) {
-        console.log(`Proposal has expired, skipping: ${deal.proposalCid['/']}`);
-        ImportUtil.knownBadProposalCids.push(deal.proposalCid['/']);
+      if (deal.Proposal.StartEpoch! < currentHeight) {
+        console.log(`Proposal has expired, skipping: ${deal.ProposalCid['/']}`);
+        ImportUtil.knownBadProposalCids.push(deal.ProposalCid['/']);
         continue;
       }
       let existingPath: string | undefined;

--- a/src/import/MinerDeal.ts
+++ b/src/import/MinerDeal.ts
@@ -20,7 +20,6 @@ export default interface MinerDeal {
   Proposal: Proposal,
   ProposalCid: Cid,
   State: number,
-  StartEpoch: number,
   Ref: {
     Root: Cid,
     PieceCid: Cid,

--- a/src/import/MinerDeal.ts
+++ b/src/import/MinerDeal.ts
@@ -20,6 +20,7 @@ export default interface MinerDeal {
   Proposal: Proposal,
   ProposalCid: Cid,
   State: number,
+  StartEpoch: number,
   Ref: {
     Root: Cid,
     PieceCid: Cid,

--- a/tests/import/ImportUtil.spec.ts
+++ b/tests/import/ImportUtil.spec.ts
@@ -32,6 +32,7 @@ describe('ImportUtil', () => {
       },
       CreationTime: new Date().toISOString(),
       State: 18,
+      StartEpoch: 99999999999,
       Ref: {
         Root: {
           '/': 'data_cid'

--- a/tests/import/ImportUtil.spec.ts
+++ b/tests/import/ImportUtil.spec.ts
@@ -32,7 +32,6 @@ describe('ImportUtil', () => {
       },
       CreationTime: new Date().toISOString(),
       State: 18,
-      StartEpoch: 99999999999,
       Ref: {
         Root: {
           '/': 'data_cid'
@@ -44,6 +43,7 @@ describe('ImportUtil', () => {
       },
       Proposal: {
         Client: 'f1client',
+        StartEpoch: 99999999999,
         Provider: 'f0miner'
       }
     };


### PR DESCRIPTION
Simple PR that stops the Import tool from trying to import Deals that are already past their StartEpoch as these will be rejected by the miner anyway.