### PR TITLE
Only export CSV with pending deals.

### DIFF
--- a/src/common/GenerateCsv.ts
+++ b/src/common/GenerateCsv.ts
@@ -19,7 +19,7 @@ export default class GenerateCsv {
         const deals = await Datastore.DealStateModel.find({
           replicationRequestId: id,
           provider: provider,
-          state: { $nin: ['slashed', 'error', 'expired', 'proposal_expired'] }
+          state: { $nin: ['active', 'slashed', 'error', 'expired', 'proposal_expired'] }
         });
         let urlPrefix = replicationRequest.urlPrefix;
         if (!urlPrefix.endsWith('/')) {

--- a/tests/common/GenerateCsv.spec.ts
+++ b/tests/common/GenerateCsv.spec.ts
@@ -10,9 +10,36 @@ describe('GenerateCsv', () => {
     await Datastore.ReplicationRequestModel.deleteMany();
     await Datastore.DealStateModel.deleteMany();
   });
+  it ('should fail export with no deals', async () => {
+    const request = await Datastore.ReplicationRequestModel.create({
+      storageProviders: 'f01001',
+      status: 'completed',
+      urlPrefix: 'http://localhost:3000'
+    });
+    const runCSV = await GenerateCsv.generate(request.id, '/tmp');
+    await expect(runCSV).toEqual(`No deal found to export in ${request.id}\n`)
+  }) 
   it ('should be able to gen with valid id', async () => {
     const request = await Datastore.ReplicationRequestModel.create({
       storageProviders: 'f01001',
+      status: 'completed',
+      urlPrefix: 'http://localhost:3000/'
+    });
+    await Datastore.DealStateModel.create({
+      dealId: 2,
+      client: 'f01001',
+      provider: 'f01001',
+      state: 'proposed',
+      replicationRequestId: request.id
+    });
+    const runCSV = await GenerateCsv.generate(request.id, '/tmp');
+    await expect(runCSV).toEqual(`CSV saved to /tmp/f01001_${request.id}.csv\n`)
+  })
+
+  it ('should be able to gen with valid id with file list path', async () => {
+    const request = await Datastore.ReplicationRequestModel.create({
+      storageProviders: 'f01001',
+      fileListPath: '-path-',
       status: 'completed',
       urlPrefix: 'http://localhost:3000'
     });
@@ -20,12 +47,15 @@ describe('GenerateCsv', () => {
       dealId: 2,
       client: 'f01001',
       provider: 'f01001',
-      state: 'active',
+      state: 'proposed',
       replicationRequestId: request.id
     });
-    await GenerateCsv.generate(request.id, '/tmp');
+    const runCSV = await GenerateCsv.generate(request.id, '/tmp');
+    await expect(runCSV).toEqual(`CSV saved to /tmp/f01001_-path-_${request.id}.csv\n`)
   })
+
   it ('should not be able to gen without valid id', async () => {
-    await GenerateCsv.generate('634b71ada25b9be2a58e434c', '/tmp');
+    const runCSV = await GenerateCsv.generate('634b71ada25b9be2a58e434c', '/tmp');
+    await expect(runCSV).toEqual(`Replication request not found 634b71ada25b9be2a58e434c`)
   })
 });


### PR DESCRIPTION
Change's the CSV export function to only export deals that are not active, errored, slashed or expired. 