### PR TITLE
Various fixes

### DIFF
--- a/src/deal-preparation/DealPreparationService.ts
+++ b/src/deal-preparation/DealPreparationService.ts
@@ -21,8 +21,8 @@ import { AbortSignal } from '../common/AbortSignal';
 import { sleep } from '../common/Util';
 import handlePostGenerateDagRequest, { generateDag } from './handler/PostGenerateDagRequestHandler';
 import handlePostPreparationAppendRequest from './handler/PostPreparationAppendRequestHandler';
-import sendError from "./handler/ErrorHandler";
-import ErrorCode from "./model/ErrorCode";
+import sendError from './handler/ErrorHandler';
+import ErrorCode from './model/ErrorCode';
 
 export default class DealPreparationService extends BaseService {
   static AllowedDealSizes: number[] = DealPreparationService.initAllowedDealSizes();

--- a/src/deal-tracking/DealTrackingService.ts
+++ b/src/deal-tracking/DealTrackingService.ts
@@ -90,7 +90,7 @@ export default class DealTrackingService extends BaseService {
      * as reference to see how many need to track
      */
 
-    response = await axios.get("https://filfox.info/api/v1/deal/list?address=" + client, {
+    response = await axios.get('https://filfox.info/api/v1/deal/list?address=' + client, {
       headers: {
         'content-type': 'application/json'
       }
@@ -102,7 +102,7 @@ export default class DealTrackingService extends BaseService {
       latestDealIdFromFilscan = response.data['deals'][0]['id']; // could be wrong
     }
     this.logger.info(`Found ${maxNumberOfDealsToTrack} deals for ${client} from filfox, latest deal id is ${latestDealIdFromFilscan}, 
-    last deal from db is ${lastDeal}, the diff is ${latestDealIdFromFilscan - lastDeal}`)
+    last deal from db is ${lastDeal}, the diff is ${latestDealIdFromFilscan - lastDeal}`);
 
     if (maxNumberOfDealsToTrack > 0 && latestDealIdFromFilscan > 0) {
       let processedCount = 0;

--- a/src/deal-tracking/DealTrackingService.ts
+++ b/src/deal-tracking/DealTrackingService.ts
@@ -33,7 +33,7 @@ export default class DealTrackingService extends BaseService {
       const client = clientState.stateKey;
       const lastDeal = await Datastore.DealStateModel.find({ client, dealId: { $ne: null } }).sort({ dealId: -1 }).limit(1);
       try {
-        await this.insertDealFromFilscan(client, lastDeal.length > 0 ? lastDeal[0].dealId! : 16000000);
+        await this.insertDealFromFilscan(client, lastDeal.length > 0 ? lastDeal[0].dealId! : 45000000);
       } catch (error) {
         this.logger.error('Encountered an error when importing deals from filescan', error);
       }
@@ -47,7 +47,7 @@ export default class DealTrackingService extends BaseService {
     }
   }
 
-  private static readonly FilscanPagination = 25;
+  // private static readonly FilscanPagination = 25;
 
   /**
    * Read from filscan api for PublishStorageDeal status
@@ -57,10 +57,10 @@ export default class DealTrackingService extends BaseService {
    */
   private async insertDealFromFilscan (client: string, lastDeal: number): Promise<void> {
     this.logger.debug('updating deals from filscan', { client, lastDeal });
-    let url = 'https://api.filscan.io:8700/rpc/v1';
-    if (client.startsWith('t')) {
-      url = 'https://calibration.filscan.io:8700/rpc/v1';
-    }
+    // let url = 'https://api.filscan.io:8700/rpc/v1';
+    // if (client.startsWith('t')) {
+    //   url = 'https://calibration.filscan.io:8700/rpc/v1';
+    // }
 
     /**
      * Find the corresponding f012345 client ID of the client address
@@ -86,29 +86,31 @@ export default class DealTrackingService extends BaseService {
     }
 
     /**
-     * We don't trust filscan's data, can only use the first deal id
+     * We don't trust filfox's data, can only use the first deal id
      * as reference to see how many need to track
      */
 
-    response = await axios.post(url, {
-      id: 1,
-      jsonrpc: '2.0',
-      params: [client, 0, DealTrackingService.FilscanPagination],
-      method: 'filscan.GetMarketDeal'
-    }, {
+    response = await axios.get("https://filfox.info/api/v1/deal/list?address=" + client, {
       headers: {
         'content-type': 'application/json'
       }
     });
 
-    const maxNumberOfDealsToTrack = response.data['result']['total'] | 0;
+    const maxNumberOfDealsToTrack = response.data['totalCount'] | 0;
     let latestDealIdFromFilscan = 0;
-    if (Array.isArray(response.data['result']['deals'])) {
-      latestDealIdFromFilscan = response.data['result']['deals'][0]['dealid']; // could be wrong
+    if (Array.isArray(response.data['deals'])) {
+      latestDealIdFromFilscan = response.data['deals'][0]['id']; // could be wrong
     }
+    this.logger.info(`Found ${maxNumberOfDealsToTrack} deals for ${client} from filfox, latest deal id is ${latestDealIdFromFilscan}, 
+    last deal from db is ${lastDeal}, the diff is ${latestDealIdFromFilscan - lastDeal}`)
+
     if (maxNumberOfDealsToTrack > 0 && latestDealIdFromFilscan > 0) {
       let processedCount = 0;
       for (let i = latestDealIdFromFilscan; i > lastDeal; i--) {
+        // log every 1000 deals
+        if (i % 1000 === 0) {
+          this.logger.info(`Count down ${i} to reach ${lastDeal}`);
+        }
         const response = await axios.post(lotusApi, {
           id: 1,
           jsonrpc: '2.0',

--- a/src/replication/DealReplicationWorker.ts
+++ b/src/replication/DealReplicationWorker.ts
@@ -21,7 +21,8 @@ export default class DealReplicationWorker extends BaseService {
   private readonly lotusCMD: string;
   private readonly boostCMD: string;
   private queryLotusBlockHeight: boolean;
-  private carSizeRequired: boolean = false; // After boost 1.7.2, car size must not be present for offline deals. https://github.com/filecoin-project/boost/pull/1421
+  // After boost 1.7.2, car size must not be present for offline deals. https://github.com/filecoin-project/boost/pull/1421
+  private carSizeRequired = false;
   // holds reference to all started crons to be updated
   private cronRefArray: Map<string, [schedule: string, taskRef: ScheduledTask]> = new Map<string, [string, ScheduledTask]>();
 
@@ -632,11 +633,11 @@ export default class DealReplicationWorker extends BaseService {
 
   /**
    * Can compare boost versions like 1.7.0 > 1.6.1
-   * @param version1 
-   * @param version2 
-   * @returns 
+   * @param version1
+   * @param version2
+   * @returns
    */
-  private compareVersions(version1: string, version2: string): number {
+  private compareVersions (version1: string, version2: string): number {
     const parts1: number[] = version1.split('.').map(Number);
     const parts2: number[] = version2.split('.').map(Number);
 
@@ -654,14 +655,14 @@ export default class DealReplicationWorker extends BaseService {
     return 0;
   }
 
-  private async checkIsBoostVersionEqualOrLessThan172(): Promise<boolean> {
+  private async checkIsBoostVersionEqualOrLessThan172 (): Promise<boolean> {
     try {
       const cmdOut = await exec(`${this.boostCMD} -v`);
       const versionStr = cmdOut?.stdout?.toString();
-      if(versionStr) {
+      if (versionStr) {
         const regex = /(\d+\.\d+\.\d+)/;
         const match = regex.exec(versionStr);
-  
+
         if (match && match.length > 0) {
           const version = match[0];
           this.logger.info(`Boost version: ${version}`);


### PR DESCRIPTION
Use filfox to get the latest deal ID as filscan been stale lately.

Adapt boost 1.7.2+ for removing car size on offline deals

Fix when car size failed to be captured by generate-car